### PR TITLE
ts関連のエラー解決

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,27 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "jsx": "preserve",
+    "target": "es5",
+    "lib": [
+      "dom",
+      "esnext"
+    ],
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowJs": true,
+    "noEmit": true,
     "incremental": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
- tsconfig.json

このエラーは、TypeScriptプロジェクトでJSX型を正しく解決できないために発生しています。この問題を解決するためには、TypeScriptとReactの関連パッケージを正しく設定する必要があります。

以下の手順で問題を解決できます。

1. 必要な依存関係のインストール
まず、React用のTypeScript型定義と関連するパッケージをインストールします。以下のコマンドを実行して、必要な依存関係をインストールしてください。

```
npm install --save-dev typescript @types/react @types/react-dom
```

2. tsconfig.json の設定確認
次に、プロジェクトのルートディレクトリにある tsconfig.json ファイルを確認し、以下のように設定されていることを確認します。

```
{
  "compilerOptions": {
    "jsx": "react-jsx",
    "target": "es5",
    "lib": ["dom", "esnext"],
    "module": "commonjs",
    "strict": true,
    "esModuleInterop": true,
    "skipLibCheck": true,
    "forceConsistentCasingInFileNames": true
  },
  "include": ["src/**/*"],
  "exclude": ["node_modules"]
}
```

特に jsx オプションが react-jsx または react に設定されていることを確認してください。これにより、TypeScriptがJSX要素を正しく認識できるようになります。

3. プロジェクトの再ビルド
これらの設定を行った後、プロジェクトを再度ビルドしてみてください。
```
npm run build
```
その後、エディタを再起動し、エラーが解消されているか確認してください。

4. 依存関係の再インストール
もしこれでも問題が解決しない場合は、依存関係を再インストールしてみてください。
```
rm -rf node_modules
rm package-lock.json
npm install
```