### PR TITLE
StoryBookでボタンとログインフォームのカタログ化(検証)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/react";
+import '../src/styles/index.css';
 
 const preview: Preview = {
   parameters: {

--- a/src/stories/PrimaryBtn.stories.tsx
+++ b/src/stories/PrimaryBtn.stories.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { PrimaryBtn } from '../components/atoms/PrimaryBtn';
+
+// Storybookのメタデータを定義
+const meta: Meta<typeof PrimaryBtn> = {
+  title: 'Components/PrimaryBtn',
+  component: PrimaryBtn,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    onClick: { action: 'clicked' }, // onClick イベントのアクションを設定
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// デフォルトのストーリーを作成
+export const Default: Story = {
+  args: {
+    children: 'ボタン',
+  },
+};
+
+// 追加のカスタマイズされたストーリーも作成できます
+export const WithDifferentText: Story = {
+  args: {
+    children: 'Sign In',
+  },
+};

--- a/src/stories/login.stories.tsx
+++ b/src/stories/login.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Login } from '../pages/login';
+
+// Storybookのメタデータを定義
+const meta: Meta<typeof Login> = {
+  title: 'Pages/Login',
+  component: Login,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// デフォルトのストーリーを作成
+export const Default: Story = {};
+
+// 追加のカスタマイズされたストーリーも作成
+export const WithPrefilledFields: Story = {
+  args: {
+    // もし初期状態や特定の挙動をテストしたい場合、ここにargsを指定します。
+  },
+};


### PR DESCRIPTION
### 変更点
- .storybook/preview.ts
- src/stories/PrimaryBtn.stories.tsx
- src/stories/login.stories.tsx

### 動作確認

<img width="1440" alt="スクリーンショット 2024-08-29 17 08 47" src="https://github.com/user-attachments/assets/5f3beb47-4317-486e-8cc3-893d608fa08c">

<img width="1437" alt="スクリーンショット 2024-08-29 17 09 37" src="https://github.com/user-attachments/assets/94d84c06-34f5-4ea6-a494-362b64e8ba90">
